### PR TITLE
Refactor input coordinates to use millis

### DIFF
--- a/src/mqttConnection.ts
+++ b/src/mqttConnection.ts
@@ -1,4 +1,7 @@
-import MqttParser, { MqttMessage } from './mqttDeserialize';
+import MqttParser, {
+  BeaconLocation,
+  mqttMessageToLocation,
+} from './mqttDeserialize';
 
 const MOCK_MESSAGE_INTERVAL = 2000;
 
@@ -6,12 +9,12 @@ const ROOM_HEIGHT_METERS = 3.8;
 
 export class FakeMqttGenerator {
   intervalRef: NodeJS.Timeout;
-  onMessage: (a: MqttMessage[]) => void;
+  onMessage: (a: BeaconLocation[]) => void;
   mqttParser: MqttParser;
 
   constructor(
     mqttParser: MqttParser,
-    onMessage: (a: MqttMessage[]) => void,
+    onMessage: (a: BeaconLocation[]) => void,
     interval: number = MOCK_MESSAGE_INTERVAL
   ) {
     this.onMessage = onMessage;
@@ -25,11 +28,11 @@ export class FakeMqttGenerator {
 
     const messages = Array.from(Array(count).keys()).map(id => {
       // Pick a random position on the 2nd floor
-      const x = 34 * Math.random();
-      const y = 7.25 + 35 * Math.random();
-      const z = ROOM_HEIGHT_METERS * Math.random();
+      const x = 34000 * Math.random();
+      const y = 7250 + 35000 * Math.random();
+      const z = ROOM_HEIGHT_METERS * 1000 * Math.random();
 
-      const messageStr = JSON.stringify({
+      const parsed = {
         beaconId: `beacon-${id}`,
         x,
         y,
@@ -38,11 +41,9 @@ export class FakeMqttGenerator {
         yr: Math.random(),
         zr: Math.random(),
         alignment: 0 - Math.random(),
-      });
+      };
 
-      const parsed = this.mqttParser.deserializeMessage(messageStr);
-
-      return parsed;
+      return mqttMessageToLocation(parsed);
     });
 
     this.onMessage(messages);

--- a/src/mqttDeserialize.ts
+++ b/src/mqttDeserialize.ts
@@ -1,27 +1,66 @@
 import * as t from 'io-ts';
 import { unsafeDecode } from './typeUtil';
 
-const MqttMessageDecoder = t.type({
+/**
+ * Represents shared properties between received MQTT location message, and
+ * parsed beacon location in our preferred format.
+ */
+const MessageLocationShared = t.type({
   /**
    * TODO: document what is beaconId and how to use it.
    */
   beaconId: t.string,
 
-  x: t.number,
-  y: t.number,
-  z: t.number,
-
+  /**
+   * Range is from 0.0 to 1.0
+   */
   xr: t.number,
   yr: t.number,
   zr: t.number,
 
   /**
-   * Should be from -1 to 0;
+   * Should be from -1.0 to 1.0;
    */
   alignment: t.number,
 });
 
+/**
+ * Raw MQTT message from the location topic. Used for type safe decoding of the
+ * json value.
+ */
+export const MqttMessageDecoder = t.intersection([
+  MessageLocationShared,
+  t.type({
+    x: t.number,
+    y: t.number,
+    z: t.number,
+  }),
+]);
+
+/**
+ * We want to have the coordinates in meters, because babylon uses meters
+ * everywhere.
+ */
+export type BeaconLocation = t.TypeOf<typeof MessageLocationShared> & {
+  xMeters: number;
+  yMeters: number;
+  zMeters: number;
+};
+
 export type MqttMessage = t.TypeOf<typeof MqttMessageDecoder>;
+
+/**
+ * Lets separate MQTT message in the API format, and our preferred format
+ * clearly. This avoids confusion between units.
+ */
+export const mqttMessageToLocation = (message: MqttMessage): BeaconLocation => {
+  return {
+    ...message,
+    xMeters: message.x / 1000,
+    yMeters: message.z / 1000,
+    zMeters: -message.y / 1000,
+  };
+};
 
 type UrlParse =
   | { kind: 'success'; url: URL }
@@ -31,8 +70,11 @@ export default class MqttParser {
   /**
    * Convert raw mqtt message into static type, crash on unexpected input.
    */
-  deserializeMessage(rawMessage: string): MqttMessage {
-    return unsafeDecode(MqttMessageDecoder, JSON.parse(rawMessage));
+  deserializeMessage(rawMessage: string): BeaconLocation {
+    return JSON.parse(rawMessage).map((obj: unknown) => {
+      const message = unsafeDecode(MqttMessageDecoder, obj);
+      return mqttMessageToLocation(message);
+    });
   }
 
   parseMqttUrl(rawUrl: string): UrlParse {

--- a/src/screen3d.ts
+++ b/src/screen3d.ts
@@ -2,7 +2,7 @@ import * as BABYLON from 'babylonjs';
 import * as GUI from 'babylonjs-gui';
 import model from '../asset/Building_Geometry_Modified.babylon';
 import { currentEnv } from './environment';
-import { MqttMessage } from './mqttDeserialize';
+import { MqttMessage, BeaconLocation } from './mqttDeserialize';
 import { Vector3 } from 'babylonjs';
 
 const FLOOR_DIMENSIONS_X = 34;
@@ -42,21 +42,21 @@ class Screen3D {
    * Convert the alignment property received from location server into format
    * Babylonjs uses.
    *
-   * - location server "alignment" range: -1 to 0
+   * - location server "alignment" range: -1 to 1.0 TODO fix
    * - BabylonJS Vector3 values range from 0 to 1 rad
    */
   sphereRotation(alignment: number): BABYLON.Vector3 {
     return new BABYLON.Vector3(0, Math.abs(alignment) * 2 * Math.PI, 0);
   }
 
-  createSphere(diameter: number, message: MqttMessage): BABYLON.Mesh {
+  createSphere(diameter: number, message: BeaconLocation): BABYLON.Mesh {
     // Create a built-in "sphere" shape; its constructor takes 6 params: name, segment, diameter, scene, updatable, sideOrientation
     const sphere = BABYLON.MeshBuilder.CreateSphere(
       'sphere1',
       {
-        diameterX: diameter + message.xr,
-        diameterY: diameter + message.yr,
-        diameterZ: diameter + message.zr,
+        diameterX: diameter + message.xr * 5,
+        diameterY: diameter + message.yr * 5,
+        diameterZ: diameter + message.zr * 5,
       },
       this.scene
     );
@@ -70,7 +70,7 @@ class Screen3D {
    * Idempotently set the 3D model beacon state to match the given messages from
    * MQTT bus.
    */
-  updateBeacons(messages: MqttMessage[]): void {
+  updateBeacons(messages: BeaconLocation[]): void {
     this.beacons.forEach(beacon => {
       beacon.label.dispose();
       beacon.mesh.dispose();
@@ -81,9 +81,9 @@ class Screen3D {
 
       // Each floor is in the XZ plane
       // The Y axis points up/down between floors
-      beacon.position.x = message.x;
-      beacon.position.z = -message.y;
-      beacon.position.y = message.z;
+      beacon.position.x = message.xMeters;
+      beacon.position.z = message.zMeters;
+      beacon.position.y = message.yMeters;
 
       const label = this.createLabel(beacon, message.beaconId);
 

--- a/src/screen3d.ts
+++ b/src/screen3d.ts
@@ -9,6 +9,17 @@ const FLOOR_DIMENSIONS_X = 34;
 const FLOOR_DIMENSIONS_Z = 7.25 + 35;
 const SPHERE_DIAMETER = 0.7;
 
+/**
+ * The beacon spheres are stretched according to the xr, yr, zr error values
+ * received from the server. How significant do we want this effect to be?
+ *
+ * TODO: find out what would be the correct way to utilize the error values from
+ * the location server. AFAIK if we have some confidence interval (like 0.95),
+ * we should be able to calculate the exact ellipsoid dimensions, without magic
+ * numbers like this one.
+ */
+const ERROR_SCALING = 5;
+
 interface LabeledBeacon {
   mesh: BABYLON.Mesh;
   label: GUI.TextBlock;
@@ -54,9 +65,9 @@ class Screen3D {
     const sphere = BABYLON.MeshBuilder.CreateSphere(
       'sphere1',
       {
-        diameterX: diameter + message.xr * 5,
-        diameterY: diameter + message.yr * 5,
-        diameterZ: diameter + message.zr * 5,
+        diameterX: diameter + message.xr * ERROR_SCALING,
+        diameterY: diameter + message.yr * ERROR_SCALING,
+        diameterZ: diameter + message.zr * ERROR_SCALING,
       },
       this.scene
     );

--- a/test/mqttDeserializeTest.ts
+++ b/test/mqttDeserializeTest.ts
@@ -1,25 +1,36 @@
-import MqttParser from '../src/mqttDeserialize';
+import MqttParser, {
+  mqttMessageToLocation,
+  BeaconLocation,
+  MqttMessageDecoder,
+} from '../src/mqttDeserialize';
+import { unsafeDecode } from '../src/typeUtil';
 
-export const exampleMessage = () => {
-  return `{
-    "beaconId": "undefined",
-    "x": 86.200010304358,
-    "y": 33.79480855847156,
-    "z": 22.23232,
-    "xr": 0.3450343712509113,
-    "yr": 0.48663315791883244,
-    "zr": 0.8,
-    "alignment": -0.4801854848714045
-  }`;
+export const exampleMessages = (): BeaconLocation[] => {
+  return Array.from(Array(10).keys()).map(index => {
+    const rawMessage = `{
+      "beaconId": "undefined-${index}",
+      "x": 86.200010304358,
+      "y": 33.79480855847156,
+      "z": 22.23232,
+      "xr": 0.3450343712509113,
+      "yr": 0.48663315791883244,
+      "zr": 0.8,
+      "alignment": -0.4801854848714045
+    }`;
+
+    const parsed = unsafeDecode(MqttMessageDecoder, JSON.parse(rawMessage));
+    const location = mqttMessageToLocation(parsed);
+
+    return location;
+  });
 };
 
 describe('MQTT parsing', () => {
   it('should parse x and y coords from the MQTT message', () => {
-    const parser = new MqttParser();
-    const parsed = parser.deserializeMessage(exampleMessage());
+    const parsed = exampleMessages();
 
-    expect(parsed.x).toBeTruthy();
-    expect(parsed.y).toBeTruthy();
+    expect(parsed[0].xMeters).toBeTruthy();
+    expect(parsed[0].yMeters).toBeTruthy();
   });
 
   it('should panic for odd input', () => {

--- a/test/screen3dTest.ts
+++ b/test/screen3dTest.ts
@@ -1,9 +1,8 @@
 import Screen3D from '../src/screen3d';
-import { exampleMessage } from './mqttDeserializeTest';
-import MqttParser from '../src/mqttDeserialize';
+import { exampleMessages } from './mqttDeserializeTest';
 
 const exampleParsedMsg = () => {
-  return new MqttParser().deserializeMessage(exampleMessage());
+  return exampleMessages()[0];
 };
 
 const createScreen = () => {
@@ -48,7 +47,7 @@ describe('Babylon.JS 3D graphics', () => {
 
     const boundingBox = res.getBoundingInfo().boundingBox.extendSize;
 
-    expect(boundingBox.x).toBeCloseTo(5.5);
+    expect(boundingBox.x).toBeCloseTo(7.5);
   });
 
   it('assigns label for created beacons', () => {
@@ -60,7 +59,7 @@ describe('Babylon.JS 3D graphics', () => {
     expect(controls.length).toBe(1);
 
     // the actual label name is "undefined"...
-    expect((labelControl as any)._text).toBe('undefined');
+    expect((labelControl as any)._text).toBe('undefined-0');
   });
 
   /**

--- a/test/screenContainerTest.tsx
+++ b/test/screenContainerTest.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MemoryRouter, Route } from 'react-router';
 import { mount } from 'enzyme';
-import { exampleMessage } from './mqttDeserializeTest';
+import { exampleMessages } from './mqttDeserializeTest';
 import { MockBusContainer, GenuineBusContainer } from '../src/screenContainer';
 
 const mockDispose = jest.fn();
@@ -12,7 +12,7 @@ jest.mock('ubimqtt', () => {
     const subscribe = jest
       .fn()
       .mockImplementation((topic: string, b: any, cb: any) =>
-        cb(topic, exampleMessage())
+        cb(topic, JSON.stringify(exampleMessages()))
       );
 
     return {


### PR DESCRIPTION
Create new type "BeaconLocation" which represents MqttMessage with
meters instead of millis. The aim is to clearly separate the input model
and the converted model, and thus avoid errors where meters and
millimeters are mixed.