### PR TITLE
Fix crash when using real mqtt bus

### DIFF
--- a/src/mqttDeserialize.ts
+++ b/src/mqttDeserialize.ts
@@ -22,7 +22,7 @@ const MessageLocationShared = t.type({
   /**
    * Should be from -1.0 to 1.0;
    */
-  alignment: t.number,
+  alignment: t.union([t.undefined, t.number]),
 });
 
 /**
@@ -75,7 +75,7 @@ export default class Deserializer {
   /**
    * Convert raw mqtt message into static type, crash on unexpected input.
    */
-  deserializeMessage(rawMessage: string): BeaconLocation {
+  deserializeMessage(rawMessage: string): BeaconLocation[] {
     return JSON.parse(rawMessage).map((obj: unknown) => {
       const message = unsafeDecode(MqttMessageDecoder, obj);
       return mqttMessageToLocation(message);

--- a/src/screen3d.ts
+++ b/src/screen3d.ts
@@ -72,7 +72,9 @@ class Screen3D {
       this.scene
     );
 
-    sphere.rotation = this.sphereRotation(message.alignment);
+    if (message.alignment !== undefined) {
+      sphere.rotation = this.sphereRotation(message.alignment);
+    }
 
     return sphere;
   }
@@ -169,8 +171,7 @@ class Screen3D {
 
   createLabel(sphere: BABYLON.Mesh, text: string) {
     // Create a text block which shows the name of the beacon
-    const label = new GUI.TextBlock();
-    label.text = text;
+    const label = new GUI.TextBlock('beaconLabel', text);
     this.labelTexture.addControl(label);
 
     // Move the label so that it tracks the position of the sphere mesh

--- a/src/screenContainer.tsx
+++ b/src/screenContainer.tsx
@@ -51,7 +51,7 @@ export const GenuineBusContainer = ({
           null,
           (topic: string, rawMessage: string) => {
             const parsed = parser.deserializeMessage(rawMessage);
-            screen.updateBeacons([parsed]);
+            screen.updateBeacons(parsed);
           },
           (subErr: any) => {
             if (subErr) {


### PR DESCRIPTION
The actual fix was to use the constructor of TextBlock instead of
setting the property.

Also few other fixes, e.g. change MqttMessage schema to accept message
with alignment property missing.