### PR TITLE
Conversion func for geographic coordinates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -500,6 +500,1337 @@
       "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
+    "@turf/along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
+      "integrity": "sha1-YdbmplhKzdq1asVYTge/jL5fi+s=",
+      "requires": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/area": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
+      "integrity": "sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/bbox": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
+      "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/bbox-clip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
+      "integrity": "sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "lineclip": "^1.1.5"
+      }
+    },
+    "@turf/bbox-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
+      "integrity": "sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
+      "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/bezier-spline": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
+      "integrity": "sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/boolean-clockwise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+      "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/boolean-contains": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
+      "integrity": "sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/boolean-crosses": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
+      "integrity": "sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/polygon-to-line": "^5.1.5"
+      }
+    },
+    "@turf/boolean-disjoint": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
+      "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/polygon-to-line": "^5.1.5"
+      }
+    },
+    "@turf/boolean-equal": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
+      "integrity": "sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=",
+      "requires": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "@turf/boolean-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
+      "integrity": "sha1-DU5kxSx3CijpPZ7834qLg3OsznU=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/line-overlap": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "@turf/boolean-parallel": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
+      "integrity": "sha1-c5NYR16ltlx+GCejw+DopofTqF0=",
+      "requires": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5"
+      }
+    },
+    "@turf/boolean-point-in-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
+      "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/boolean-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
+      "integrity": "sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/boolean-within": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
+      "integrity": "sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/buffer": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
+      "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/projection": "^5.1.5",
+        "d3-geo": "1.7.1",
+        "turf-jsts": "*"
+      }
+    },
+    "@turf/center": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
+      "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/center-mean": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
+      "integrity": "sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/center-median": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
+      "integrity": "sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=",
+      "requires": {
+        "@turf/center-mean": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/center-of-mass": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
+      "integrity": "sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=",
+      "requires": {
+        "@turf/centroid": "^5.1.5",
+        "@turf/convex": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/centroid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
+      "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
+      "integrity": "sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=",
+      "requires": {
+        "@turf/destination": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/clean-coords": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
+      "integrity": "sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/clusters": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
+      "integrity": "sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/clusters-dbscan": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
+      "integrity": "sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "density-clustering": "1.3.0"
+      }
+    },
+    "@turf/clusters-kmeans": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
+      "integrity": "sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "skmeans": "0.9.7"
+      }
+    },
+    "@turf/collect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
+      "integrity": "sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "rbush": "^2.0.1"
+      },
+      "dependencies": {
+        "quickselect": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+        },
+        "rbush": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+          "requires": {
+            "quickselect": "^1.0.1"
+          }
+        }
+      }
+    },
+    "@turf/combine": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
+      "integrity": "sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/concave": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
+      "integrity": "sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/tin": "^5.1.5",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x"
+      }
+    },
+    "@turf/convex": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
+      "integrity": "sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "concaveman": "*"
+      }
+    },
+    "@turf/destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
+      "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/difference": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
+      "integrity": "sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=",
+      "requires": {
+        "@turf/area": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "@turf/dissolve": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
+      "integrity": "sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=",
+      "requires": {
+        "@turf/boolean-overlap": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/union": "^5.1.5",
+        "geojson-rbush": "2.1.0",
+        "get-closest": "*"
+      }
+    },
+    "@turf/distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
+      "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
+      "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/transform-rotate": "^5.1.5"
+      }
+    },
+    "@turf/envelope": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
+      "integrity": "sha1-UBMwnFP91D369LWIplw/7X28EIo=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/bbox-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/explode": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
+      "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/flatten": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
+      "integrity": "sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/flip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
+      "integrity": "sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/great-circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
+      "integrity": "sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+    },
+    "@turf/hex-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
+      "integrity": "sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=",
+      "requires": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/interpolate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
+      "integrity": "sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/hex-grid": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/point-grid": "^5.1.5",
+        "@turf/square-grid": "^5.1.5",
+        "@turf/triangle-grid": "^5.1.5"
+      }
+    },
+    "@turf/intersect": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
+      "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
+      "requires": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/truncate": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "@turf/invariant": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
+      "integrity": "sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/isobands": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
+      "integrity": "sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=",
+      "requires": {
+        "@turf/area": "^5.1.5",
+        "@turf/bbox": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/isolines": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
+      "integrity": "sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/kinks": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
+      "integrity": "sha1-irtpYdm7AQchO63fLCwmQNAlaYA=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/length": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
+      "integrity": "sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=",
+      "requires": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/line-arc": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
+      "integrity": "sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=",
+      "requires": {
+        "@turf/circle": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/line-chunk": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
+      "integrity": "sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/length": "^5.1.5",
+        "@turf/line-slice-along": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/line-intersect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
+      "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "@turf/line-offset": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
+      "integrity": "sha1-KrWy8In4yRPiMdmUN4553KkLWh4=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/line-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
+      "integrity": "sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=",
+      "requires": {
+        "@turf/boolean-point-on-line": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "@turf/line-segment": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
+      "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/line-slice": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
+      "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5"
+      }
+    },
+    "@turf/line-slice-along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
+      "integrity": "sha1-7drQoh70efKWihG9LdcomiEy6aU=",
+      "requires": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/line-split": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
+      "integrity": "sha1-Wy30w3YZty73JbUWPPmSbVVArLc=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/line-segment": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/nearest-point-on-line": "^5.1.5",
+        "@turf/square": "^5.1.5",
+        "@turf/truncate": "^5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "@turf/line-to-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
+      "integrity": "sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/mask": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
+      "integrity": "sha1-mrD+8aJyyY/j70kvn/thggayQtU=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/union": "^5.1.5",
+        "rbush": "^2.0.1"
+      },
+      "dependencies": {
+        "quickselect": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+        },
+        "rbush": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+          "requires": {
+            "quickselect": "^1.0.1"
+          }
+        }
+      }
+    },
+    "@turf/meta": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
+      "integrity": "sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/midpoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
+      "integrity": "sha1-4mH2srDqgSTM7/VSomLdRlydBfA=",
+      "requires": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/nearest-point": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
+      "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/nearest-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
+      "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
+      "requires": {
+        "@turf/bearing": "^5.1.5",
+        "@turf/destination": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-intersect": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/nearest-point-to-line": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
+      "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
+      "requires": {
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "@turf/meta": "6.x",
+        "@turf/point-to-line-distance": "^5.1.5",
+        "object-assign": "*"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
+          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+        },
+        "@turf/invariant": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
+          "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
+          "requires": {
+            "@turf/helpers": "6.x"
+          }
+        },
+        "@turf/meta": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
+          "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+          "requires": {
+            "@turf/helpers": "6.x"
+          }
+        }
+      }
+    },
+    "@turf/planepoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
+      "integrity": "sha1-GLvfAG91ne9eQsagBsn53oGyt/8=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/point-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
+      "integrity": "sha1-MFFBJI9Quv42zn5mukuX56sjaIc=",
+      "requires": {
+        "@turf/boolean-within": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/point-on-feature": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
+      "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/explode": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/nearest-point": "^5.1.5"
+      }
+    },
+    "@turf/point-to-line-distance": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
+      "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
+      "requires": {
+        "@turf/bearing": "6.x",
+        "@turf/distance": "6.x",
+        "@turf/helpers": "6.x",
+        "@turf/invariant": "6.x",
+        "@turf/meta": "6.x",
+        "@turf/projection": "6.x",
+        "@turf/rhumb-bearing": "6.x",
+        "@turf/rhumb-distance": "6.x"
+      },
+      "dependencies": {
+        "@turf/bearing": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.0.1.tgz",
+          "integrity": "sha512-mXY1NozqV9EFfBTbUItujwfqfQF0G/Xe2fzvnZle90ekPEUfhi4Dgf5JswJTd96J9LiT8kcd6Jonp5khnx0wIg==",
+          "requires": {
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x"
+          }
+        },
+        "@turf/clone": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.0.2.tgz",
+          "integrity": "sha512-UVpYPnW3wRj3bPncR6Z2PRbowBk+nEdVWgGewPxrKKLfvswtVtG9n/OIyvbU3E3ZOadBVxTH2uAMEMOz4800FA==",
+          "requires": {
+            "@turf/helpers": "6.x"
+          }
+        },
+        "@turf/distance": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.0.1.tgz",
+          "integrity": "sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==",
+          "requires": {
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x"
+          }
+        },
+        "@turf/helpers": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
+          "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+        },
+        "@turf/invariant": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
+          "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
+          "requires": {
+            "@turf/helpers": "6.x"
+          }
+        },
+        "@turf/meta": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
+          "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+          "requires": {
+            "@turf/helpers": "6.x"
+          }
+        },
+        "@turf/projection": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.0.1.tgz",
+          "integrity": "sha512-Y3RvGT6I53MjYKLG69e9sMk45wJXcLbrEO1t6P3WQQQGqA2gYhhMJyV41vE2Z2llrJpvs2dDx/tIeQzGd0HHMQ==",
+          "requires": {
+            "@turf/clone": "6.x",
+            "@turf/helpers": "6.x",
+            "@turf/meta": "6.x"
+          }
+        },
+        "@turf/rhumb-bearing": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.0.1.tgz",
+          "integrity": "sha512-MVBra8OVfjM4+/N0B3o6cBIYg9p/uRKzA9uk05RfrzasEbUL1vdD23LkTooVL74Yw4UxL8BQD9hS5Re2COJFDA==",
+          "requires": {
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x"
+          }
+        },
+        "@turf/rhumb-distance": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.0.1.tgz",
+          "integrity": "sha512-3G45DQtQByzzfHFPcCyJdUZFwsd45zfZ7sAb1ddF7mhEj4G70+T2G3GKjInymqDNrbyh2gbG6wQiZSToC8Uf9g==",
+          "requires": {
+            "@turf/helpers": "6.x",
+            "@turf/invariant": "6.x"
+          }
+        }
+      }
+    },
+    "@turf/points-within-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
+      "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/polygon-tangents": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
+      "integrity": "sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/polygon-to-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
+      "integrity": "sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/polygonize": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
+      "integrity": "sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/envelope": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/projection": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+      "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/random": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
+      "integrity": "sha1-sy78k0Vgroulfo67UfJBw5+6Lns=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/rewind": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+      "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
+      "requires": {
+        "@turf/boolean-clockwise": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/rhumb-destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
+      "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/sample": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
+      "integrity": "sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/sector": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
+      "integrity": "sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=",
+      "requires": {
+        "@turf/circle": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/line-arc": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/shortest-path": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
+      "integrity": "sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/bbox-polygon": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/transform-scale": "^5.1.5"
+      }
+    },
+    "@turf/simplify": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
+      "integrity": "sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=",
+      "requires": {
+        "@turf/clean-coords": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/square": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
+      "integrity": "sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=",
+      "requires": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/square-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
+      "integrity": "sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=",
+      "requires": {
+        "@turf/boolean-contains": "^5.1.5",
+        "@turf/boolean-overlap": "^5.1.5",
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/standard-deviational-ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
+      "integrity": "sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=",
+      "requires": {
+        "@turf/center-mean": "^5.1.5",
+        "@turf/ellipse": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/points-within-polygon": "^5.1.5"
+      }
+    },
+    "@turf/tag": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
+      "integrity": "sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/tesselate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
+      "integrity": "sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "earcut": "^2.0.0"
+      }
+    },
+    "@turf/tin": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
+      "integrity": "sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=",
+      "requires": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "@turf/transform-rotate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
+      "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
+      "requires": {
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/rhumb-distance": "^5.1.5"
+      }
+    },
+    "@turf/transform-scale": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
+      "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
+      "requires": {
+        "@turf/bbox": "^5.1.5",
+        "@turf/center": "^5.1.5",
+        "@turf/centroid": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-bearing": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5",
+        "@turf/rhumb-distance": "^5.1.5"
+      }
+    },
+    "@turf/transform-translate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
+      "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
+      "requires": {
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "@turf/rhumb-destination": "^5.1.5"
+      }
+    },
+    "@turf/triangle-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
+      "integrity": "sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=",
+      "requires": {
+        "@turf/distance": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/intersect": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "@turf/truncate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
+      "integrity": "sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "@turf/turf": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
+      "integrity": "sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=",
+      "requires": {
+        "@turf/along": "5.1.x",
+        "@turf/area": "5.1.x",
+        "@turf/bbox": "5.1.x",
+        "@turf/bbox-clip": "5.1.x",
+        "@turf/bbox-polygon": "5.1.x",
+        "@turf/bearing": "5.1.x",
+        "@turf/bezier-spline": "5.1.x",
+        "@turf/boolean-clockwise": "5.1.x",
+        "@turf/boolean-contains": "5.1.x",
+        "@turf/boolean-crosses": "5.1.x",
+        "@turf/boolean-disjoint": "5.1.x",
+        "@turf/boolean-equal": "5.1.x",
+        "@turf/boolean-overlap": "5.1.x",
+        "@turf/boolean-parallel": "5.1.x",
+        "@turf/boolean-point-in-polygon": "5.1.x",
+        "@turf/boolean-point-on-line": "5.1.x",
+        "@turf/boolean-within": "5.1.x",
+        "@turf/buffer": "5.1.x",
+        "@turf/center": "5.1.x",
+        "@turf/center-mean": "5.1.x",
+        "@turf/center-median": "5.1.x",
+        "@turf/center-of-mass": "5.1.x",
+        "@turf/centroid": "5.1.x",
+        "@turf/circle": "5.1.x",
+        "@turf/clean-coords": "5.1.x",
+        "@turf/clone": "5.1.x",
+        "@turf/clusters": "5.1.x",
+        "@turf/clusters-dbscan": "5.1.x",
+        "@turf/clusters-kmeans": "5.1.x",
+        "@turf/collect": "5.1.x",
+        "@turf/combine": "5.1.x",
+        "@turf/concave": "5.1.x",
+        "@turf/convex": "5.1.x",
+        "@turf/destination": "5.1.x",
+        "@turf/difference": "5.1.x",
+        "@turf/dissolve": "5.1.x",
+        "@turf/distance": "5.1.x",
+        "@turf/ellipse": "5.1.x",
+        "@turf/envelope": "5.1.x",
+        "@turf/explode": "5.1.x",
+        "@turf/flatten": "5.1.x",
+        "@turf/flip": "5.1.x",
+        "@turf/great-circle": "5.1.x",
+        "@turf/helpers": "5.1.x",
+        "@turf/hex-grid": "5.1.x",
+        "@turf/interpolate": "5.1.x",
+        "@turf/intersect": "5.1.x",
+        "@turf/invariant": "5.1.x",
+        "@turf/isobands": "5.1.x",
+        "@turf/isolines": "5.1.x",
+        "@turf/kinks": "5.1.x",
+        "@turf/length": "5.1.x",
+        "@turf/line-arc": "5.1.x",
+        "@turf/line-chunk": "5.1.x",
+        "@turf/line-intersect": "5.1.x",
+        "@turf/line-offset": "5.1.x",
+        "@turf/line-overlap": "5.1.x",
+        "@turf/line-segment": "5.1.x",
+        "@turf/line-slice": "5.1.x",
+        "@turf/line-slice-along": "5.1.x",
+        "@turf/line-split": "5.1.x",
+        "@turf/line-to-polygon": "5.1.x",
+        "@turf/mask": "5.1.x",
+        "@turf/meta": "5.1.x",
+        "@turf/midpoint": "5.1.x",
+        "@turf/nearest-point": "5.1.x",
+        "@turf/nearest-point-on-line": "5.1.x",
+        "@turf/nearest-point-to-line": "5.1.x",
+        "@turf/planepoint": "5.1.x",
+        "@turf/point-grid": "5.1.x",
+        "@turf/point-on-feature": "5.1.x",
+        "@turf/point-to-line-distance": "5.1.x",
+        "@turf/points-within-polygon": "5.1.x",
+        "@turf/polygon-tangents": "5.1.x",
+        "@turf/polygon-to-line": "5.1.x",
+        "@turf/polygonize": "5.1.x",
+        "@turf/projection": "5.1.x",
+        "@turf/random": "5.1.x",
+        "@turf/rewind": "5.1.x",
+        "@turf/rhumb-bearing": "5.1.x",
+        "@turf/rhumb-destination": "5.1.x",
+        "@turf/rhumb-distance": "5.1.x",
+        "@turf/sample": "5.1.x",
+        "@turf/sector": "5.1.x",
+        "@turf/shortest-path": "5.1.x",
+        "@turf/simplify": "5.1.x",
+        "@turf/square": "5.1.x",
+        "@turf/square-grid": "5.1.x",
+        "@turf/standard-deviational-ellipse": "5.1.x",
+        "@turf/tag": "5.1.x",
+        "@turf/tesselate": "5.1.x",
+        "@turf/tin": "5.1.x",
+        "@turf/transform-rotate": "5.1.x",
+        "@turf/transform-scale": "5.1.x",
+        "@turf/transform-translate": "5.1.x",
+        "@turf/triangle-grid": "5.1.x",
+        "@turf/truncate": "5.1.x",
+        "@turf/union": "5.1.x",
+        "@turf/unkink-polygon": "5.1.x",
+        "@turf/voronoi": "5.1.x"
+      }
+    },
+    "@turf/union": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
+      "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "turf-jsts": "*"
+      }
+    },
+    "@turf/unkink-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
+      "integrity": "sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=",
+      "requires": {
+        "@turf/area": "^5.1.5",
+        "@turf/boolean-point-in-polygon": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/meta": "^5.1.5",
+        "rbush": "^2.0.1"
+      },
+      "dependencies": {
+        "quickselect": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+        },
+        "rbush": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+          "requires": {
+            "quickselect": "^1.0.1"
+          }
+        }
+      }
+    },
+    "@turf/voronoi": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
+      "integrity": "sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=",
+      "requires": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "d3-voronoi": "1.1.2"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
@@ -2111,8 +3442,7 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "commist": {
       "version": "1.1.0",
@@ -2173,6 +3503,38 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "concaveman": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.1.1.tgz",
+      "integrity": "sha1-bCSCWAslI874L8K+wAoEFebmgWI=",
+      "requires": {
+        "monotone-convex-hull-2d": "^1.0.1",
+        "point-in-polygon": "^1.0.1",
+        "rbush": "^2.0.1",
+        "robust-orientation": "^1.1.3",
+        "tinyqueue": "^1.1.0"
+      },
+      "dependencies": {
+        "quickselect": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+          "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
+        },
+        "rbush": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+          "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+          "requires": {
+            "quickselect": "^1.0.1"
+          }
+        },
+        "tinyqueue": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
+          "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
+        }
       }
     },
     "connect-history-api-fallback": {
@@ -2521,6 +3883,24 @@
         "type": "^1.0.1"
       }
     },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "requires": {
+        "d3-array": "1"
+      }
+    },
+    "d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2583,8 +3963,7 @@
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -2680,6 +4059,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "density-clustering": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
+      "integrity": "sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU="
     },
     "depd": {
       "version": "1.1.2",
@@ -4305,6 +5689,24 @@
         "is-callable": "^1.1.3"
       }
     },
+    "geojson-equality": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
+      "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
+      "requires": {
+        "deep-equal": "^1.0.0"
+      }
+    },
+    "geojson-rbush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
+      "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
+      "requires": {
+        "@turf/helpers": "*",
+        "@turf/meta": "*",
+        "rbush": "*"
+      }
+    },
     "geojson-vt": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
@@ -4315,6 +5717,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
+    },
+    "get-closest": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
+      "integrity": "sha1-JprHdtHmAiqg/Vht1wjop9Miaa8="
     },
     "get-stdin": {
       "version": "7.0.0",
@@ -6138,6 +7545,11 @@
         "type-check": "~0.3.2"
       }
     },
+    "lineclip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
+      "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM="
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -6583,6 +7995,14 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
+      }
+    },
+    "monotone-convex-hull-2d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
+      "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
+      "requires": {
+        "robust-orientation": "^1.1.3"
       }
     },
     "moo": {
@@ -7448,6 +8868,11 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
+    "point-in-polygon": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.0.1.tgz",
+      "integrity": "sha1-1Ztk6P7kHElFiqyCtWcYxZV7Kvc="
+    },
     "portfinder": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
@@ -7839,6 +9264,14 @@
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
           "dev": true
         }
+      }
+    },
+    "rbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.0.tgz",
+      "integrity": "sha512-hb6ViijtI77X4lyhfYDsjOc6icrJPVdHsxf44vYiGctsrWJNXoPtR6Uzvo8F562mJZysjn8YRI9jNKvDPK4ozQ==",
+      "requires": {
+        "quickselect": "^2.0.0"
       }
     },
     "react": {
@@ -8244,6 +9677,36 @@
         "inherits": "^2.0.1"
       }
     },
+    "robust-orientation": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
+      "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
+      "requires": {
+        "robust-scale": "^1.0.2",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.2"
+      }
+    },
+    "robust-scale": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
+      "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+      "requires": {
+        "two-product": "^1.0.2",
+        "two-sum": "^1.0.0"
+      }
+    },
+    "robust-subtract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
+      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+    },
+    "robust-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
+      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
+    },
     "rst-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -8560,6 +10023,11 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
       "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
       "dev": true
+    },
+    "skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg=="
     },
     "slash": {
       "version": "2.0.0",
@@ -9379,6 +10847,22 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
+    "topojson-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.0.tgz",
+      "integrity": "sha1-H5kpOnfvQqRI0DKoGqmCtz82DS8=",
+      "requires": {
+        "commander": "2"
+      }
+    },
+    "topojson-server": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.0.tgz",
+      "integrity": "sha1-N4546Hw5cqe1vixdYENptrrmnF4=",
+      "requires": {
+        "commander": "2"
+      }
+    },
     "toposort": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
@@ -9577,11 +11061,26 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "turf-jsts": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
+      "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
+    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
+    },
+    "two-product": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
+      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+    },
+    "two-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
+      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
     },
     "type": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@turf/turf": "^5.1.6",
     "babylonjs": "^4.0.3",
     "babylonjs-gui": "^4.0.3",
     "dotenv": "^8.0.0",

--- a/src/location/mqttConnection.ts
+++ b/src/location/mqttConnection.ts
@@ -1,6 +1,6 @@
 import Deserializer, {
-  BeaconLocation,
-  mqttMessageToLocation,
+  BabylonBeacon,
+  mqttMessageToBabylon,
 } from './mqttDeserialize';
 
 const MOCK_MESSAGE_INTERVAL = 2000;
@@ -9,12 +9,12 @@ const ROOM_HEIGHT_METERS = 3.8;
 
 export class FakeMqttGenerator {
   intervalRef: number;
-  onMessage: (a: BeaconLocation[]) => void;
+  onMessage: (a: BabylonBeacon[]) => void;
   mqttParser: Deserializer;
 
   constructor(
     mqttParser: Deserializer,
-    onMessage: (a: BeaconLocation[]) => void,
+    onMessage: (a: BabylonBeacon[]) => void,
     interval: number = MOCK_MESSAGE_INTERVAL
   ) {
     this.onMessage = onMessage;
@@ -43,7 +43,7 @@ export class FakeMqttGenerator {
         alignment: 0 - Math.random(),
       };
 
-      return mqttMessageToLocation(parsed);
+      return mqttMessageToBabylon(parsed);
     });
 
     this.onMessage(messages);

--- a/src/location/mqttDeserialize.ts
+++ b/src/location/mqttDeserialize.ts
@@ -1,6 +1,13 @@
 import * as t from 'io-ts';
 import queryStringParser from 'query-string';
 import { unsafeDecode } from '../common/typeUtil';
+import destination from '@turf/destination';
+
+const LIBRARY_BEARING = 42.5;
+const LIBRARY_ORIGO = {
+  lat: 60.205325,
+  lon: 24.962115,
+};
 
 /**
  * Represents shared properties between received MQTT location message, and
@@ -42,7 +49,7 @@ export const MqttMessageDecoder = t.intersection([
  * We want to have the coordinates in meters, because babylon uses meters
  * everywhere.
  */
-export type BeaconLocation = t.TypeOf<typeof MessageLocationShared> & {
+export type BabylonBeacon = t.TypeOf<typeof MessageLocationShared> & {
   xMeters: number;
   yMeters: number;
   zMeters: number;
@@ -51,15 +58,56 @@ export type BeaconLocation = t.TypeOf<typeof MessageLocationShared> & {
 export type MqttMessage = t.TypeOf<typeof MqttMessageDecoder>;
 
 /**
- * Lets separate MQTT message in the API format, and our preferred format
- * clearly. This avoids confusion between units.
+ * Convert untouched mqtt message into babylon-friendly format. Babylon uses
+ * meters as coordinate units.
  */
-export const mqttMessageToLocation = (message: MqttMessage): BeaconLocation => {
+export const mqttMessageToBabylon = (message: MqttMessage): BabylonBeacon => {
   return {
     ...message,
     xMeters: message.x / 1000,
     yMeters: message.z / 1000,
     zMeters: -message.y / 1000,
+  };
+};
+
+export type BeaconGeoLocation = t.TypeOf<typeof MessageLocationShared> & {
+  lat: number;
+  lon: number;
+  height: number;
+};
+
+/**
+ * Convert the location server message into geographic coordinates so that
+ * mapbox can use them.
+ */
+export const mqttMessageToGeo = (message: MqttMessage): BeaconGeoLocation => {
+  const firstAxis = destination(
+    [LIBRARY_ORIGO.lon, LIBRARY_ORIGO.lat],
+    message.y / 1000,
+    -90 - LIBRARY_BEARING,
+    { units: 'metres' }
+  );
+
+  if (firstAxis.geometry === null) {
+    throw new Error('invalid coords: ' + message);
+  }
+
+  const finalCoords = destination(
+    [firstAxis.geometry.coordinates[0], firstAxis.geometry.coordinates[1]],
+    message.x / 1000,
+    180 - LIBRARY_BEARING,
+    { units: 'metres' }
+  );
+
+  if (finalCoords.geometry === null) {
+    throw new Error('invalid coords: ' + message);
+  }
+
+  return {
+    ...message,
+    lat: finalCoords.geometry.coordinates[1],
+    lon: finalCoords.geometry.coordinates[0],
+    height: message.z,
   };
 };
 
@@ -75,10 +123,10 @@ export default class Deserializer {
   /**
    * Convert raw mqtt message into static type, crash on unexpected input.
    */
-  deserializeMessage(rawMessage: string): BeaconLocation[] {
+  deserializeMessage(rawMessage: string): BabylonBeacon[] {
     return JSON.parse(rawMessage).map((obj: unknown) => {
       const message = unsafeDecode(MqttMessageDecoder, obj);
-      return mqttMessageToLocation(message);
+      return mqttMessageToBabylon(message);
     });
   }
 

--- a/src/location/mqttDeserialize.ts
+++ b/src/location/mqttDeserialize.ts
@@ -5,8 +5,8 @@ import destination from '@turf/destination';
 
 const LIBRARY_BEARING = 42.5;
 const LIBRARY_ORIGO = {
-  lat: 60.205325,
-  lon: 24.962115,
+  lat: 60.205318,
+  lon: 24.962113,
 };
 
 /**

--- a/src/location/mqttDeserializeTest.ts
+++ b/src/location/mqttDeserializeTest.ts
@@ -1,26 +1,31 @@
 import Deserializer, {
-  mqttMessageToLocation,
-  BeaconLocation,
+  mqttMessageToBabylon,
+  BabylonBeacon,
   MqttMessageDecoder,
+  mqttMessageToGeo,
 } from './mqttDeserialize';
 import * as t from 'io-ts';
 import { unsafeDecode } from '../common/typeUtil';
 
-export const exampleMessages = (): BeaconLocation[] => {
-  return Array.from(Array(10).keys()).map(index => {
-    const rawMessage = `{
-      "beaconId": "undefined-${index}",
-      "x": 86.200010304358,
-      "y": 33.79480855847156,
-      "z": 22.23232,
-      "xr": 0.3450343712509113,
-      "yr": 0.48663315791883244,
-      "zr": 0.8,
-      "alignment": -0.4801854848714045
-    }`;
+const exampleMqttMessage = (index: number) => {
+  const rawMessage = `{
+    "beaconId": "undefined-${index}",
+    "x": 86.200010304358,
+    "y": 33.79480855847156,
+    "z": 22.23232,
+    "xr": 0.3450343712509113,
+    "yr": 0.48663315791883244,
+    "zr": 0.8,
+    "alignment": -0.4801854848714045
+  }`;
 
-    const parsed = unsafeDecode(MqttMessageDecoder, JSON.parse(rawMessage));
-    const location = mqttMessageToLocation(parsed);
+  return unsafeDecode(MqttMessageDecoder, JSON.parse(rawMessage));
+};
+
+export const exampleMessages = (): BabylonBeacon[] => {
+  return Array.from(Array(10).keys()).map(index => {
+    const mqttMessage = exampleMqttMessage(index);
+    const location = mqttMessageToBabylon(mqttMessage);
 
     return location;
   });
@@ -83,5 +88,52 @@ describe('query string parsing', () => {
 
     expect(parser.parseQuery(decoder, '?lat=50.5').lat).toBeCloseTo(50.5);
     expect(parser.parseQuery(decoder, 'lat=50.1').lat).toBeCloseTo(50.1);
+  });
+});
+
+describe('geographic coordinate conversion', () => {
+  it('should convert zero coordinates nearby to the origo', () => {
+    const input = exampleMqttMessage(1);
+    input.x = 0.0;
+    input.y = 0.0;
+
+    const geoCoords = mqttMessageToGeo(input);
+
+    const kumpulaOrigo = {
+      lat: 60.205325,
+      lon: 24.962115,
+    };
+
+    expect(geoCoords.lat).toBeCloseTo(kumpulaOrigo.lat);
+    expect(geoCoords.lon).toBeCloseTo(kumpulaOrigo.lon);
+  });
+
+  it('should give the western corner when y is large', () => {
+    const input = exampleMqttMessage(1);
+    input.x = 0.0;
+    input.y = 41000.0; // length of library wall
+
+    const westCorner = {
+      lat: 60.2050755,
+      lon: 24.9615679,
+    };
+
+    const geoCoords = mqttMessageToGeo(input);
+
+    expect(geoCoords.lat).toBeCloseTo(westCorner.lat, 5);
+    expect(geoCoords.lon).toBeCloseTo(westCorner.lon, 5);
+  });
+
+  it('should give the southern corner if both x and y are large', () => {
+    const input = exampleMqttMessage(1);
+    input.x = 30000.0;
+    input.y = 41000.0;
+
+    const southCorner = { lat: 60.2048748, lon: 24.961934255 };
+
+    const geoCoords = mqttMessageToGeo(input);
+
+    expect(geoCoords.lat).toBeCloseTo(southCorner.lat, 5);
+    expect(geoCoords.lon).toBeCloseTo(southCorner.lon, 5);
   });
 });

--- a/src/location/mqttDeserializeTest.ts
+++ b/src/location/mqttDeserializeTest.ts
@@ -114,7 +114,7 @@ describe('geographic coordinate conversion', () => {
     input.y = 41000.0; // length of library wall
 
     const westCorner = {
-      lat: 60.2050755,
+      lat: 60.2050688,
       lon: 24.9615679,
     };
 

--- a/src/visualization/screen3d.ts
+++ b/src/visualization/screen3d.ts
@@ -2,7 +2,7 @@ import * as BABYLON from 'babylonjs';
 import * as GUI from 'babylonjs-gui';
 import model from '../../asset/Building_Geometry_Modified.babylon';
 import { currentEnv } from '../common/environment';
-import { BeaconLocation } from '../location/mqttDeserialize';
+import { BabylonBeacon } from '../location/mqttDeserialize';
 
 const FLOOR_DIMENSIONS_X = 34;
 const FLOOR_DIMENSIONS_Z = 7.25 + 35;
@@ -59,7 +59,7 @@ class Screen3D {
     return new BABYLON.Vector3(0, Math.abs(alignment) * 2 * Math.PI, 0);
   }
 
-  createSphere(diameter: number, message: BeaconLocation): BABYLON.Mesh {
+  createSphere(diameter: number, message: BabylonBeacon): BABYLON.Mesh {
     // Create a built-in "sphere" shape; its constructor takes 6 params: name, segment, diameter, scene, updatable, sideOrientation
     const sphere = BABYLON.MeshBuilder.CreateSphere(
       'sphere1',
@@ -82,7 +82,7 @@ class Screen3D {
    * Idempotently set the 3D model beacon state to match the given messages from
    * MQTT bus.
    */
-  updateBeacons(messages: BeaconLocation[]): void {
+  updateBeacons(messages: BabylonBeacon[]): void {
     this.beacons.forEach(beacon => {
       beacon.label.dispose();
       beacon.mesh.dispose();


### PR DESCRIPTION
Utilize turf.js library.

Previously we had two main data types for the location messages sent by the server, MqttMessage and BeaconLocation (with units in babylon format).

Rename `BeaconLocation` into `BabylonBeacon` and add new type: `BeaconGeoLocation`. This new type represents the coordinates in geographic wgs84 lat/lon format.