### PR TITLE
Add floor plan into the tileserver-gl dataset

### DIFF
--- a/client/src/map/style.json
+++ b/client/src/map/style.json
@@ -21,6 +21,10 @@
     "openmaptiles": {
       "type": "vector",
       "url": "http://localhost:8000/data/helsinki.json"
+    },
+    "library_floorplan": {
+      "type": "raster",
+      "url": "http://localhost:8000/data/helsinkiraster.json"
     }
   },
   "sprite": "https://openmaptiles.github.io/positron-gl-style/sprite",
@@ -1061,6 +1065,12 @@
           "stops": [[3, "rgb(157,169,177)"], [4, "rgb(153, 153, 153)"]]
         }
       }
+    },
+    {
+      "id": "library",
+      "type": "raster",
+      "source": "library_floorplan",
+      "source-layer": "library_floorplan"
     }
   ],
   "id": "positron"

--- a/maptiles/Dockerfile
+++ b/maptiles/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /build && curl -L -o /build/floorplan_v5.tif "https://drive.google.com
 WORKDIR /build
 
 # This is the actual GeoTIFF -> mbtiles conversion
-RUN gdal_translate -of MBTILES -co BLOCKSIZE=512 floorplan_v5.tif floorplan_v5.mbtiles
+RUN gdal_translate -of MBTILES -co BLOCKSIZE=2048 -co ZOOM_LEVEL_STRATEGY=UPPER floorplan_v5.tif floorplan_v5.mbtiles
 
 # Add different zoom levels.
 # TODO: minimum zoom level is 16, how do we add smaller zoom levels?

--- a/maptiles/Dockerfile
+++ b/maptiles/Dockerfile
@@ -1,3 +1,20 @@
+FROM osgeo/gdal:alpine-normal-v2.4.1 AS mbtilebuilder
+
+# See https://github.com/UrbanSystemsLab/raster-to-mbtiles#2-gdal_translate
+
+RUN apk add --no-cache curl
+
+RUN mkdir /build && curl -L -o /build/floorplan_v5.tif "https://drive.google.com/uc?export=download&id=16nNCcRJZEXJA9cYphWiFdKMI3OvY0078"
+
+WORKDIR /build
+
+# This is the actual GeoTIFF -> mbtiles conversion
+RUN gdal_translate -of MBTILES -co BLOCKSIZE=512 floorplan_v5.tif floorplan_v5.mbtiles
+
+# Add different zoom levels.
+# TODO: minimum zoom level is 16, how do we add smaller zoom levels?
+RUN gdaladdo -r average floorplan_v5.mbtiles 2 4 8 16 32
+
 FROM klokantech/tileserver-gl:latest
 
 # See this repo for instructions for generating the .mbtiles file https://github.com/openmaptiles/openmaptiles#build
@@ -11,5 +28,6 @@ RUN node ./generate.js
 RUN cp -r _output /server/fonts
 
 COPY opts.json /server/opts.json
+COPY --from=mbtilebuilder /build/floorplan_v5.mbtiles /server
 
 CMD ["/bin/bash", "/usr/src/app/run.sh", "--config", "/server/opts.json"]

--- a/maptiles/opts.json
+++ b/maptiles/opts.json
@@ -24,6 +24,9 @@
   "data": {
     "helsinki": {
       "mbtiles": "helsinki.mbtiles"
+    },
+    "helsinkiraster": {
+      "mbtiles": "floorplan_v5.mbtiles"
     }
   }
 }


### PR DESCRIPTION
Download the geotiff file from google drive, and use GDAL for mbtiles conversion.

NOTE: only zoom levels 16-21 are generated, for some reason GDAL doesn't make more levels...