### PR TITLE
Fix: dropdown menu appears below the correct link

### DIFF
--- a/client/src/common/navBar.tsx
+++ b/client/src/common/navBar.tsx
@@ -270,19 +270,18 @@ const NavBar = ({
               <TiLocationArrow />
             </Icon>
             <RightMenuText>Location Sharing</RightMenuText>
+            <ShareLocationDropdown
+              isOpen={isShareLocationDropdownOpen}
+              openDropdown={openShareLocationDropdown}
+              onOpenShareLocationModal={navigateHomeAndRun(() => {
+                openShareLocationDropdown(false);
+                openShareLocationModal(true);
+              })}
+              onOpenPublishLocationModal={navigateHomeAndRun(() => {
+                openPublicShare(true);
+              })}
+            />
           </RightMenuItem>
-
-          <ShareLocationDropdown
-            isOpen={isShareLocationDropdownOpen}
-            openDropdown={openShareLocationDropdown}
-            onOpenShareLocationModal={navigateHomeAndRun(() => {
-              openShareLocationDropdown(false);
-              openShareLocationModal(true);
-            })}
-            onOpenPublishLocationModal={navigateHomeAndRun(() => {
-              openPublicShare(true);
-            })}
-          />
 
           {isAdmin && (
             <RightMenuItem


### PR DESCRIPTION
Previously, the "Location Sharing" dropdown menu appeared below the search box.